### PR TITLE
Fix conflict with neovim.

### DIFF
--- a/plugin/cscope_maps.vim
+++ b/plugin/cscope_maps.vim
@@ -38,12 +38,14 @@ if has("cscope")
     " if you want the reverse search order.
     set csto=0
 
-    " add any cscope database in current directory
-    if filereadable("cscope.out")
-        cs add cscope.out  
-    " else add the database pointed to by environment variable 
-    elseif $CSCOPE_DB != ""
-        cs add $CSCOPE_DB
+    if (!has("nvim")) " nvim already loads the default cscope database by default?
+        " add any cscope database in current directory
+        if filereadable("cscope.out")
+            cs add cscope.out  
+        " else add the database pointed to by environment variable 
+        elseif $CSCOPE_DB != ""
+            cs add $CSCOPE_DB
+        endif
     endif
 
     " show msg when any other cscope db added


### PR DESCRIPTION
- neovim seems to load the cscope database by default, so explicitly
  loading it again throws an error on startup (adding duplicate database).
  Added a check when running neovim which then skips loading the cscope
  database.