### PR TITLE
revert cscope DB load exclusion for neovim

### DIFF
--- a/plugin/cscope_maps.vim
+++ b/plugin/cscope_maps.vim
@@ -38,16 +38,15 @@ if has("cscope")
     " if you want the reverse search order.
     set csto=0
 
-    if (!has("nvim")) " nvim already loads the default cscope database by default?
-        " add any cscope database in current directory
-        if filereadable("cscope.out")
-            cs add cscope.out  
-        " else add the database pointed to by environment variable 
-        elseif $CSCOPE_DB != ""
-            cs add $CSCOPE_DB
-        endif
+    
+    " add any cscope database in current directory
+    if filereadable("cscope.out")
+        cs add cscope.out  
+    " else add the database pointed to by environment variable 
+    elseif $CSCOPE_DB != ""
+        cs add $CSCOPE_DB
     endif
-
+    
     " show msg when any other cscope db added
     set cscopeverbose  
 


### PR DESCRIPTION
revert exclusion for neovim. 
it is still needed. initial issue was related to my personal setup/config which duplicated auto-loading of cscope DB